### PR TITLE
maker.me to app.maker.co cuz faster than redirect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ export default class MakerEnahance extends React.Component {
 
     script = document.createElement("script");
     script.id = "maker-enhance-script";
-    script.src = `https://maker.me/enhance/${this.props.user}.js`;
+    script.src = `https://app.maker.co/enhance/${this.props.user}.js`;
     document.head.appendChild(script);
   }
 


### PR DESCRIPTION
would love to change maker.me to app.maker.co for good because i wanna kill unnecessary dns redirects whenever possible. 