### PR TITLE
use different strategy to prevent rerender during hydration

### DIFF
--- a/lib/MakerEnhance.d.ts
+++ b/lib/MakerEnhance.d.ts
@@ -1,8 +1,7 @@
-/// <reference types="react" />
 interface MakerEnhanceProps {
     user: string;
     instanceId?: string | number;
     loadingHeight?: number;
 }
-export default function MakerEnhance({ user, instanceId, loadingHeight, }: MakerEnhanceProps): JSX.Element;
+export default function MakerEnhance({ user, instanceId, loadingHeight, }: MakerEnhanceProps): JSX.Element | null;
 export {};

--- a/lib/MakerEnhance.js
+++ b/lib/MakerEnhance.js
@@ -7,6 +7,7 @@ exports["default"] = MakerEnhance;
 var _react = _interopRequireDefault(require("react"));
 var _MakerEnhanceClient = _interopRequireDefault(require("./MakerEnhanceClient"));
 function _interopRequireDefault(e) { return e && e.__esModule ? e : { "default": e }; }
+var isBrowser = typeof window !== "undefined";
 function MakerEnhance(_ref) {
   var user = _ref.user,
     instanceId = _ref.instanceId,
@@ -15,11 +16,8 @@ function MakerEnhance(_ref) {
   var id = "js-maker-static-enhance-v1-218c2d7d-62da-499e-9e74-93201e1b3d56-".concat(instanceId || "0");
   var html = "\n    <script src=\"".concat(scriptSrc, "\" id=\"maker-enhance-script\" async=\"true\"></script>\n    <div\n      id=\"").concat(id, "\"\n      class=\"js-maker-enhance-static-mount\"\n      style=\"height:auto;width:100%\"\n      ").concat(loadingHeight ? "data-loading-height=\"".concat(loadingHeight, "\"") : "", "\n    ></div>\n  ");
 
-  // https://github.com/facebook/react/issues/10923#issuecomment-338715787
-  // "We won't try to manipulate the tree of a dangerouslySetInnerHTML node on the client. Even if it is wrong."
-  //
-  // Use dangerouslySetInnerHTML to avoid issues with hydration.
-  return /*#__PURE__*/_react["default"].createElement(_react["default"].Fragment, null, /*#__PURE__*/_react["default"].createElement(_MakerEnhanceClient["default"], {
+  // If component was rendered on server, don't rerender on client
+  return isBrowser && document.getElementById(id) ? null : /*#__PURE__*/_react["default"].createElement(_react["default"].Fragment, null, /*#__PURE__*/_react["default"].createElement(_MakerEnhanceClient["default"], {
     user: user,
     id: id,
     scriptSrc: scriptSrc

--- a/lib/MakerEnhanceClient.d.ts
+++ b/lib/MakerEnhanceClient.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="react" />
 interface MakerEnhanceClientProps {
     user: string;
     id: string;

--- a/src/MakerEnhance.tsx
+++ b/src/MakerEnhance.tsx
@@ -7,11 +7,13 @@ interface MakerEnhanceProps {
   loadingHeight?: number;
 }
 
+const isBrowser = typeof window !== "undefined";
+
 export default function MakerEnhance({
   user,
   instanceId,
   loadingHeight,
-}: MakerEnhanceProps): JSX.Element {
+}: MakerEnhanceProps): JSX.Element | null {
   const scriptSrc = `https://app.maker.co/enhance/${user}.js`;
   const id = `js-maker-static-enhance-v1-218c2d7d-62da-499e-9e74-93201e1b3d56-${
     instanceId || "0"
@@ -27,11 +29,8 @@ export default function MakerEnhance({
     ></div>
   `;
 
-  // https://github.com/facebook/react/issues/10923#issuecomment-338715787
-  // "We won't try to manipulate the tree of a dangerouslySetInnerHTML node on the client. Even if it is wrong."
-  //
-  // Use dangerouslySetInnerHTML to avoid issues with hydration.
-  return (
+  // If component was rendered on server, don't rerender on client
+  return isBrowser && document.getElementById(id) ? null : (
     <>
       <MakerEnhanceClient user={user} id={id} scriptSrc={scriptSrc} />
       <div


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevent client-side re-rendering of `MakerEnhance` by returning `null` if already rendered on server.
> 
>   - **Behavior**:
>     - `MakerEnhance` in `MakerEnhance.js` and `MakerEnhance.tsx` now returns `null` if the component is already present in the DOM, preventing client-side re-rendering.
>     - Uses `isBrowser` to check for browser environment before accessing `document`.
>   - **Type Definitions**:
>     - Update return type of `MakerEnhance` in `MakerEnhance.d.ts` and `MakerEnhance.tsx` to `JSX.Element | null`.
>     - Remove unnecessary `/// <reference types="react" />` from `MakerEnhance.d.ts` and `MakerEnhanceClient.d.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=makerinc%2Fmaker-enhance&utm_source=github&utm_medium=referral)<sup> for a507a71f17c3fff1747368e1b05e2180c0d8cd13. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->